### PR TITLE
SourceClear: fixes for vulnerable libraries

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -71,19 +71,19 @@
 		{
 			"checksumSHA1": "JWyVxkLtx2Dw4C2jNfQJV2C3YRA=",
 			"path": "github.com/square/go-jose",
-			"revision": "7f0dd807d3f3d73bb536898cb7980ddf638ce69a",
+			"revision": "v2.1.0",
 			"revisionTime": "2016-08-31T18:22:30Z"
 		},
 		{
 			"checksumSHA1": "JJd0NOYIZQQc8WwqhfW9OwPvGa4=",
 			"path": "github.com/square/go-jose/cipher",
-			"revision": "7f0dd807d3f3d73bb536898cb7980ddf638ce69a",
+			"revision": "v2.1.0",
 			"revisionTime": "2016-08-31T18:22:30Z"
 		},
 		{
 			"checksumSHA1": "MjFMyZLaQYCfJyi3O0ynKNSmneA=",
 			"path": "github.com/square/go-jose/json",
-			"revision": "7f0dd807d3f3d73bb536898cb7980ddf638ce69a",
+			"revision": "v2.1.0",
 			"revisionTime": "2016-08-31T18:22:30Z"
 		},
 		{


### PR DESCRIPTION
This pull request fixes one or more vulnerable libraries in this project.

For more information, please navigate to the corresponding [SourceClear report](https://spencer.sourceclear.io/teams/mZZUlEP/scans/6513525).

SourceClear generated this pull request to update the following vulnerable libraries:

| Type | Library | From | To |
| --- | --- | --- | --- |
| GOVENDOR | `github.com/square/go-jose` | HEAD | v2.1.0 |

The column above, **Breaking**, will state the likelihood that updating to the recommended library version will have breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/reader/hHHR3gv0wYc2WbCclECf_A/root) for documentation.

Note: this pull request was generated because you or someone else with access to this repository has granted SourceClear access to submit pull requests.
<!-- srcclr-pr-id-54b510758f3f060028980a51d86f6d5daf5af570f20f9aebeb825e00dd9a1c61 -->
